### PR TITLE
feat: Create initial project structure for ideviceerase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Compiler and compiler flags
+CC = gcc
+CFLAGS = -Wall -Isrc # -Wall enables all warnings, -Isrc to find headers in src/
+
+# Linker flags - for specifying library paths
+LDFLAGS = # e.g., -L/usr/local/lib or -L/path/to/libimobiledevice/lib
+
+# Libraries to link against
+LIBS = # e.g., -limobiledevice-1.0 -lusbmuxd # Placeholder for libimobiledevice and libusbmuxd
+
+# Name of the executable
+TARGET = ideviceerase
+
+# Source files and object files
+SRCS = src/ideviceerase.c
+OBJS = $(SRCS:.c=.o) # Replaces .c with .o, so src/ideviceerase.c becomes src/ideviceerase.o
+
+# Default target: builds the executable
+all: $(TARGET)
+
+# Target to link the executable
+$(TARGET): $(OBJS)
+	@echo "Linking $(TARGET)..."
+	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
+	@echo "$(TARGET) built successfully."
+
+# Target to compile C source files into object files
+# This is a pattern rule that applies to any .o file that depends on a .c file in src/
+src/%.o: src/%.c
+	@echo "Compiling $<..."
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+# Clean target: removes build artifacts
+clean:
+	@echo "Cleaning up build artifacts..."
+	rm -f $(TARGET) $(OBJS)
+	@echo "Cleanup complete."
+
+# Phony targets: targets that don't represent actual files
+.PHONY: all clean

--- a/src/ideviceerase.c
+++ b/src/ideviceerase.c
@@ -1,0 +1,84 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+
+// Global variables to store parsed arguments
+static char *udid = NULL;
+static char *ecid = NULL;
+static int debug_flag = 0;
+
+// Function to print usage information
+void print_usage(const char *prog_name) {
+    fprintf(stderr, "Usage: %s -u <device_udid> [--ecid <value>] [--debug]\n", prog_name);
+    fprintf(stderr, "  -u, --udid <device_udid>   : Target device UDID (mandatory).\n");
+    fprintf(stderr, "      --ecid <value>         : Target device ECID.\n");
+    fprintf(stderr, "      --debug                : Enable debug output.\n");
+}
+
+int main(int argc, char *argv[]) {
+    int opt;
+    // Define long options
+    static struct option long_options[] = {
+        {"udid",    required_argument, 0, 'u'},
+        {"ecid",    required_argument, 0, 'e'}, // Using 'e' as a short option internally for ecid
+        {"debug",   no_argument,       0, 'd'}, // Using 'd' as a short option internally for debug
+        {0, 0, 0, 0} // Terminating entry
+    };
+    int option_index = 0;
+
+    // Argument parsing loop
+    // The '+' in "+u:e:d" means getopt stops scanning as soon as a non-option argument is found.
+    // 'u:' means -u takes an argument. 'e:' means --ecid (internally 'e') takes an argument. 'd' means --debug (internally 'd') is a flag.
+    while ((opt = getopt_long(argc, argv, "+u:e:d", long_options, &option_index)) != -1) {
+        switch (opt) {
+            case 'u':
+                udid = optarg;
+                break;
+            case 'e': // Corresponds to --ecid
+                ecid = optarg;
+                break;
+            case 'd': // Corresponds to --debug
+                debug_flag = 1;
+                break;
+            case '?': // Unknown option or missing argument
+                // getopt_long already prints an error message
+                print_usage(argv[0]);
+                return 1;
+            default:
+                // This case should ideally not be reached if '+' is used in optstring
+                // and all long options have corresponding short options or are handled.
+                abort(); 
+        }
+    }
+
+    // Check for mandatory arguments
+    if (udid == NULL) {
+        fprintf(stderr, "Error: UDID is a mandatory argument.\n");
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    // Print parsed arguments
+    printf("Program: ideviceerase\n");
+    printf("UDID: %s\n", udid);
+    if (ecid) {
+        printf("ECID: %s\n", ecid);
+    } else {
+        printf("ECID: Not provided\n");
+    }
+    printf("Debug mode: %s\n", debug_flag ? "enabled" : "disabled");
+
+    // Handle non-option arguments if any (not expected for this tool)
+    if (optind < argc) {
+        fprintf(stderr, "Unexpected non-option arguments: ");
+        while (optind < argc) {
+            fprintf(stderr, "%s ", argv[optind++]);
+        }
+        fprintf(stderr, "\n");
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    return 0; // Success
+}


### PR DESCRIPTION
I've set up the basic framework for the ideviceerase command-line tool as described in the README.md.

This includes:
- A `src` directory for source code.
- `src/ideviceerase.c`: A basic C file with command-line argument parsing for UDID, ECID, and a debug flag. It currently prints the parsed arguments.
- `Makefile`: A basic makefile to compile the C source into an `ideviceerase` executable and clean build artifacts. It includes commented placeholders for `libimobiledevice` and `libusbmuxd` dependencies.

This commit establishes the foundation for further development of the ideviceerase tool.